### PR TITLE
Set not declared optional parameters to their default values.

### DIFF
--- a/src/CallableReflection.php
+++ b/src/CallableReflection.php
@@ -360,7 +360,9 @@ class CallableReflection
         foreach ($this->getReflector()->getParameters() as $position => $reflectedParam) {
             if (array_key_exists($reflectedParam->name, $args)) {
                 $params[$position] = $args[$reflectedParam->name];
-            } elseif (!$reflectedParam->isOptional()) {
+            } elseif ($reflectedParam->isOptional()) {
+                $params[$position] = $reflectedParam->getDefaultValue();
+            } else {
                 throw new \InvalidArgumentException(
                     sprintf(
                         'Missing key "%s" for the %sth params of %s',

--- a/tests/CallableReflectionTest.php
+++ b/tests/CallableReflectionTest.php
@@ -133,40 +133,46 @@ class CallableReflectionTest extends \PHPUnit_Framework_TestCase
     public function testInvokeAForClosure()
     {
         $reflectedCallable = new CallableReflection($this->getClosure());
-        $this->assertSame(array(2, 1), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2)));
+        $this->assertSame(array(2, 1, 3, 4), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2)));
     }
 
     public function testInvokeAForInstanceMethod()
     {
         $reflectedCallable = new CallableReflection($this->getInstanceMethod());
-        $this->assertSame(array(2, 1), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2)));
+        $this->assertSame(array(2, 1, 3, 4), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2)));
     }
 
     public function testInvokeAForStaticMethod()
     {
         $reflectedCallable = new CallableReflection($this->getStaticMethod1());
-        $this->assertSame(array(2, 1), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2)));
+        $this->assertSame(array(2, 1, 3, 4), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2)));
 
         $reflectedCallable = new CallableReflection($this->getStaticMethod2());
-        $this->assertSame(array(2, 1), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2)));
+        $this->assertSame(array(2, 1, 3, 4), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2)));
     }
 
     public function testInvokeAForInvokedObject()
     {
         $reflectedCallable = new CallableReflection($this->getInvokedObject());
-        $this->assertSame(array(2, 1), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2)));
+        $this->assertSame(array(2, 1, 3, 4), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2)));
     }
 
     public function testInvokeAWithOptionalParameter()
     {
         $reflectedCallable = new CallableReflection($this->getInstanceMethod());
-        $this->assertSame(array(2, 1, 3), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2, 'c' => 3)));
+        $this->assertSame(array(2, 1, 5, 4), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2, 'c' => 5)));
+    }
+
+    public function testInvokeAWithNotFirstOptionalParameter()
+    {
+        $reflectedCallable = new CallableReflection($this->getInstanceMethod());
+        $this->assertSame(array(2, 1, 3, 5), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2, 'd' => 5)));
     }
 
     public function testInvokeAWithUndeclaredParameter()
     {
         $reflectedCallable = new CallableReflection($this->getInstanceMethod());
-        $this->assertSame(array(2, 1), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2, 'd' => 4)));
+        $this->assertSame(array(2, 1, 3, 4), $reflectedCallable->invokeA(array('b' => 1, 'a' => 2, 'e' => 6)));
     }
 
     /**
@@ -254,28 +260,28 @@ class CallableReflectionTest extends \PHPUnit_Framework_TestCase
     public function testInvokeAStaticForClosure()
     {
         $reflectedCallable = new CallableReflection($this->getClosure());
-        $this->assertSame(array(2, 1), $reflectedCallable->invokeAStatic(array('b' => 1, 'a' => 2)));
+        $this->assertSame(array(2, 1, 3, 4), $reflectedCallable->invokeAStatic(array('b' => 1, 'a' => 2)));
     }
 
     public function testInvokeAStaticForInstanceMethod()
     {
         $reflectedCallable = new CallableReflection($this->getInstanceMethod());
-        $this->assertSame(array(2, 1), $reflectedCallable->invokeAStatic(array('b' => 1, 'a' => 2)));
+        $this->assertSame(array(2, 1, 3, 4), $reflectedCallable->invokeAStatic(array('b' => 1, 'a' => 2)));
     }
 
     public function testInvokeAStaticForStaticMethod()
     {
         $reflectedCallable = new CallableReflection($this->getStaticMethod1());
-        $this->assertSame(array(2, 1), $reflectedCallable->invokeAStatic(array('b' => 1, 'a' => 2)));
+        $this->assertSame(array(2, 1, 3, 4), $reflectedCallable->invokeAStatic(array('b' => 1, 'a' => 2)));
 
         $reflectedCallable = new CallableReflection($this->getStaticMethod2());
-        $this->assertSame(array(2, 1), $reflectedCallable->invokeAStatic(array('b' => 1, 'a' => 2)));
+        $this->assertSame(array(2, 1, 3, 4), $reflectedCallable->invokeAStatic(array('b' => 1, 'a' => 2)));
     }
 
     public function testInvokeAStaticForInvokedObject()
     {
         $reflectedCallable = new CallableReflection($this->getInvokedObject());
-        $this->assertSame(array(2, 1), $reflectedCallable->invokeAStatic(array('b' => 1, 'a' => 2)));
+        $this->assertSame(array(2, 1, 3, 4), $reflectedCallable->invokeAStatic(array('b' => 1, 'a' => 2)));
     }
 
     public function testGetTypeForFunction()
@@ -655,7 +661,7 @@ class CallableReflectionTest extends \PHPUnit_Framework_TestCase
      */
     private function getClosure()
     {
-        return function ($a, $b, $c = 3) {
+        return function ($a, $b, $c = 3, $d = 4) {
             return func_get_args();
         };
     }

--- a/tests/resources/Callback.php
+++ b/tests/resources/Callback.php
@@ -4,17 +4,17 @@ namespace TRex\Reflection\resources;
 class Callback
 {
 
-    public static function bar($a, $b, $c = 3)
+    public static function bar($a, $b, $c = 3, $d = 4)
     {
         return func_get_args();
     }
 
-    public function foo($a, $b, $c = 3)
+    public function foo($a, $b, $c = 3, $d = 4)
     {
         return func_get_args();
     }
 
-    public function __invoke($a, $b, $c = 3)
+    public function __invoke($a, $b, $c = 3, $d = 4)
     {
         return func_get_args();
     }


### PR DESCRIPTION
This is necessary so that all parameters get their values when only second optional parameter is passed. This fixes #1.
